### PR TITLE
Update to BooPickle 1.2.2

### DIFF
--- a/scala-serialization/pom.xml
+++ b/scala-serialization/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>me.chrons</groupId>
             <artifactId>boopickle_2.11</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
@@ -5,13 +5,20 @@ import java.time.Instant
 import java.util
 
 import boopickle.Default._
+import boopickle.{BufferPool, DecoderSize, EncoderSize}
 import com.komanov.serialization.domain._
 
 /** https://github.com/ochrons/boopickle */
 object BoopickleConverter extends MyConverter {
 
+  implicit def pickleState = new PickleState(new EncoderSize, false)
+  implicit val unpickleState = (bb: ByteBuffer) => new UnpickleState(new DecoderSize(bb), false)
+
   override def toByteArray(site: Site): Array[Byte] = {
-    bbToArray(Pickle.intoBytes(site))
+    val bb = Pickle.intoBytes(site)
+    val a = bbToArray(bb)
+    BufferPool.release(bb)
+    a
   }
 
   override def fromByteArray(bytes: Array[Byte]): Site = {
@@ -19,7 +26,10 @@ object BoopickleConverter extends MyConverter {
   }
 
   override def toByteArray(event: SiteEvent): Array[Byte] = {
-    bbToArray(Pickle.intoBytes(event))
+    val bb = Pickle.intoBytes(event)
+    val a = bbToArray(bb)
+    BufferPool.release(bb)
+    a
   }
 
   override def siteEventFromByteArray(clazz: Class[_], bytes: Array[Byte]): SiteEvent = {


### PR DESCRIPTION
Using BufferPool and deduplication optimizations.

Benchmark results against ScalaPb greatly improved with BooPickle 1.2.2

```
Benchmark                                     Mode  Cnt       Score       Error  Units
BooPickleBenchmark.deserialization_events_1k  avgt    8   229609.104 ±  4242.107  ns/op
BooPickleBenchmark.deserialization_site_1k    avgt    8   216134.240 ± 18494.926  ns/op
BooPickleBenchmark.serialization_events_1k    avgt    8   422911.898 ±  5323.671  ns/op
BooPickleBenchmark.serialization_site_1k      avgt    8   196177.728 ±  2557.183  ns/op

ScalaPbBenchmark.deserialization_events_1k    avgt    8   285279.364 ±  3876.583  ns/op
ScalaPbBenchmark.deserialization_site_1k      avgt    8   222347.930 ±  3681.500  ns/op
ScalaPbBenchmark.serialization_events_1k      avgt    8   176360.710 ±  2602.926  ns/op
ScalaPbBenchmark.serialization_site_1k        avgt    8   211022.158 ±  1988.583  ns/op

BooPickleBenchmark.deserialization_events_8k  avgt    8  1768908.652 ±  17513.814  ns/op
BooPickleBenchmark.deserialization_site_8k    avgt    8  1422387.766 ±  12860.004  ns/op
BooPickleBenchmark.serialization_events_8k    avgt    8  3616248.455 ± 185977.014  ns/op
BooPickleBenchmark.serialization_site_8k      avgt    8  1553459.067 ±  20589.341  ns/op

ScalaPbBenchmark.deserialization_events_8k    avgt    8  2353689.162 ±  88123.777  ns/op
ScalaPbBenchmark.deserialization_site_8k      avgt    8  1527833.290 ±  16712.442  ns/op
ScalaPbBenchmark.serialization_events_8k      avgt    8  1484782.695 ±  16108.905  ns/op
ScalaPbBenchmark.serialization_site_8k        avgt    8  1606841.680 ±  23519.552  ns/op
```
