### PR TITLE
Update to BooPickle 1.2.3

### DIFF
--- a/scala-serialization-test/src/main/scala/com/komanov/serialization/jmh/Benchmarks.scala
+++ b/scala-serialization-test/src/main/scala/com/komanov/serialization/jmh/Benchmarks.scala
@@ -38,6 +38,12 @@ abstract class BenchmarkBase(converter: MyConverter) {
   private val events8kOutput = createEventsOutput(site8k)
   private val events64kOutput = createEventsOutput(site64k)
 
+  private val eventSeq1kOutput = createEventSeqOutput(site1k)
+  private val eventSeq2kOutput = createEventSeqOutput(site2k)
+  private val eventSeq4kOutput = createEventSeqOutput(site4k)
+  private val eventSeq8kOutput = createEventSeqOutput(site8k)
+  private val eventSeq64kOutput = createEventSeqOutput(site64k)
+
   @Benchmark
   def serialization_site_1k(): Array[Byte] = {
     converter.toByteArray(site1k)
@@ -158,6 +164,56 @@ abstract class BenchmarkBase(converter: MyConverter) {
     }
   }
 
+  @Benchmark
+  def serialization_eventseq_1k(): Any = {
+    converter.toByteArray(events1kInput)
+  }
+
+  @Benchmark
+  def serialization_eventseq_2k(): Any = {
+    converter.toByteArray(events2kInput)
+  }
+
+  @Benchmark
+  def serialization_eventseq_4k(): Any = {
+    converter.toByteArray(events4kInput)
+  }
+
+  @Benchmark
+  def serialization_eventseq_8k(): Any = {
+    converter.toByteArray(events8kInput)
+  }
+
+  @Benchmark
+  def serialization_eventseq_64k(): Any = {
+    converter.toByteArray(events64kInput)
+  }
+
+  @Benchmark
+  def deserialization_eventseq_1k(): Any = {
+    converter.siteEventSeqFromByteArray(eventSeq1kOutput)
+  }
+
+  @Benchmark
+  def deserialization_eventseq_2k(): Any = {
+    converter.siteEventSeqFromByteArray(eventSeq2kOutput)
+  }
+
+  @Benchmark
+  def deserialization_eventseq_4k(): Any = {
+    converter.siteEventSeqFromByteArray(eventSeq4kOutput)
+  }
+
+  @Benchmark
+  def deserialization_eventseq_8k(): Any = {
+    converter.siteEventSeqFromByteArray(eventSeq8kOutput)
+  }
+
+  @Benchmark
+  def deserialization_eventseq_64k(): Any = {
+    converter.siteEventSeqFromByteArray(eventSeq64kOutput)
+  }
+
   private def createEventsInput(site: Site): Seq[SiteEvent] = {
     EventProcessor.unapply(site).map(_.event)
   }
@@ -166,6 +222,9 @@ abstract class BenchmarkBase(converter: MyConverter) {
     EventProcessor.unapply(site).map(_.event).map(e => e.getClass -> converter.toByteArray(e))
   }
 
+  private def createEventSeqOutput(site: Site): Array[Byte] = {
+    converter.toByteArray(EventProcessor.unapply(site).map(_.event))
+  }
 }
 
 class JsonBenchmark extends BenchmarkBase(JsonConverter)

--- a/scala-serialization/pom.xml
+++ b/scala-serialization/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>me.chrons</groupId>
             <artifactId>boopickle_2.11</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
@@ -11,8 +11,8 @@ import com.komanov.serialization.domain._
 /** https://github.com/ochrons/boopickle */
 object BoopickleConverter extends MyConverter {
 
-  implicit def pickleState = new PickleState(new EncoderSize, false)
-  implicit val unpickleState = (bb: ByteBuffer) => new UnpickleState(new DecoderSize(bb), false)
+  implicit def pickleState = new PickleState(new EncoderSize, false, false)
+  implicit val unpickleState = (bb: ByteBuffer) => new UnpickleState(new DecoderSize(bb), false, false)
 
   override def toByteArray(site: Site): Array[Byte] = {
     val bb = Pickle.intoBytes(site)
@@ -42,9 +42,13 @@ object BoopickleConverter extends MyConverter {
 
   implicit val instantPickler = transformPickler[Instant, Long](t => Instant.ofEpochMilli(t))(_.toEpochMilli)
 
-  implicit val pageComponentTypePickler = transformPickler(PageComponentType.valueOf)(_.name())
-  implicit val siteFlagPickler = transformPickler(SiteFlag.valueOf)(_.name())
-  implicit val siteTypePickler = transformPickler(SiteType.valueOf)(_.name())
+  val pageComponentTypeValues = PageComponentType.values()
+  val siteFlagValues = SiteFlag.values()
+  val siteTypeValues = SiteType.values()
+
+  implicit val pageComponentTypePickler = transformPickler((i: Int) => pageComponentTypeValues(i))(_.ordinal())
+  implicit val siteFlagPickler = transformPickler((i: Int) => siteFlagValues(i))(_.ordinal())
+  implicit val siteTypePickler = transformPickler((i: Int) => siteTypeValues(i))(_.ordinal())
 
   implicit val entryPointPickler = compositePickler[EntryPoint]
     .addConcreteType[DomainEntryPoint]

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
@@ -36,6 +36,17 @@ object BoopickleConverter extends MyConverter {
     Unpickle[SiteEvent].fromBytes(ByteBuffer.wrap(bytes))
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = {
+    val bb = Pickle.intoBytes(events)
+    val a = bbToArray(bb)
+    BufferPool.release(bb)
+    a
+  }
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = {
+    Unpickle[Seq[SiteEvent]].fromBytes(ByteBuffer.wrap(bytes))
+  }
+
   private def bbToArray(bb: ByteBuffer) = {
     util.Arrays.copyOfRange(bb.array(), 0, bb.limit())
   }

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/ChillConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/ChillConverter.scala
@@ -24,4 +24,12 @@ object ChillConverter extends MyConverter {
     pool.fromBytes(bytes, clazz).asInstanceOf[SiteEvent]
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = {
+    pool.toBytesWithClass(events)
+  }
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = {
+    pool.fromBytes(bytes).asInstanceOf[Seq[SiteEvent]]
+  }
+
 }

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/EventConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/EventConverter.scala
@@ -8,4 +8,8 @@ trait EventConverter {
 
   def siteEventFromByteArray(clazz: Class[_], bytes: Array[Byte]): SiteEvent
 
+  def toByteArray(events: Seq[SiteEvent]): Array[Byte]
+
+  def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent]
+
 }

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaPbConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaPbConverter.scala
@@ -79,6 +79,10 @@ object JavaPbConverter extends MyConverter {
     fromMessage(parser(bytes))
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
   private def toMetaTagPb(mt: MetaTag) = {
     MetaTagPb.newBuilder()
       .setName(mt.name)

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaSerializationConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaSerializationConverter.scala
@@ -43,4 +43,8 @@ object JavaSerializationConverter extends MyConverter {
     }
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
 }

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaThriftConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/JavaThriftConverter.scala
@@ -79,6 +79,10 @@ object JavaThriftConverter extends MyConverter {
     fromMessage(m)
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
   private def serializer = new TSerializer(new TBinaryProtocol.Factory())
 
   private def deserializer = new TDeserializer(new TBinaryProtocol.Factory())

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/JsonConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/JsonConverter.scala
@@ -62,4 +62,8 @@ object JsonConverter extends MyConverter {
     objectMapper.readValue(bytes, clazz).asInstanceOf[SiteEvent]
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
 }

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/PicklingConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/PicklingConverter.scala
@@ -28,6 +28,14 @@ object PicklingConverter extends MyConverter {
     bytes.unpickle[SiteEvent]
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = {
+    events.pickle.value
+  }
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = {
+    bytes.unpickle[Seq[SiteEvent]]
+  }
+
   private implicit val pageComponentTypePickler = new JavaEnumPickler[PageComponentType]
   private implicit val siteFlagPickler = new JavaEnumPickler[SiteFlag]
   private implicit val siteTypePickler = new JavaEnumPickler[SiteType]

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/ScalaPbConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/ScalaPbConverter.scala
@@ -77,6 +77,10 @@ object ScalaPbConverter extends MyConverter {
     fromMessage(parse(bytes))
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
   private def toMetaTagPb(mt: MetaTag) = MetaTagPb(mt.name, mt.value)
 
   private def fromMetaTagPb(mt: MetaTagPb) = MetaTag(mt.name, mt.value)

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/ScroogeConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/ScroogeConverter.scala
@@ -78,6 +78,10 @@ object ScroogeConverter extends MyConverter {
     fromMessage(codec.decode(new TBinaryProtocol(transport)))
   }
 
+  override def toByteArray(events: Seq[SiteEvent]): Array[Byte] = Array.empty[Byte]
+
+  override def siteEventSeqFromByteArray(bytes: Array[Byte]): Seq[SiteEvent] = Seq.empty
+
   private def toMetaTagPb(mt: MetaTag) = {
     new MetaTagPb.Immutable(Option(mt.name), Option(mt.value))
   }


### PR DESCRIPTION
Java Enums are now encoded using ordinals instead of names.
