### PR TITLE
Update to BooPickle 1.2.4

### DIFF
--- a/scala-serialization/pom.xml
+++ b/scala-serialization/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>me.chrons</groupId>
             <artifactId>boopickle_2.11</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>

--- a/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
+++ b/scala-serialization/src/main/scala/com/komanov/serialization/converters/BoopickleConverter.scala
@@ -11,8 +11,10 @@ import com.komanov.serialization.domain._
 /** https://github.com/ochrons/boopickle */
 object BoopickleConverter extends MyConverter {
 
-  implicit def pickleState = new PickleState(new EncoderSize, false)
-  implicit val unpickleState = (bb: ByteBuffer) => new UnpickleState(new DecoderSize(bb), false)
+  implicit def pickleState = new PickleState(new EncoderSize, false, false)
+  implicit val unpickleState = (bb: ByteBuffer) => new UnpickleState(new DecoderSize(bb), false, false)
+
+  BufferPool.disable()
 
   override def toByteArray(site: Site): Array[Byte] = {
     val bb = Pickle.intoBytes(site)


### PR DESCRIPTION
Disable all deduplication.

Disable BufferPool as it slows down in a multi-threaded congestion case.

This update makes BooPickle significantly faster in all test cases.
